### PR TITLE
Updated default.rb to assume ENV['PATH'] is sufficient to specify cpan a...

### DIFF
--- a/lib/puppet/provider/cpan/default.rb
+++ b/lib/puppet/provider/cpan/default.rb
@@ -1,8 +1,9 @@
 Puppet::Type.type(:cpan).provide( :default ) do
   @doc = "Manages cpan modules"
 
-  commands :cpan => '/usr/bin/cpan'
-  commands :perl => '/usr/bin/perl'
+  commands :cpan     => 'cpan'
+  commands :perl     => 'perl'
+  confine  :osfamily => [:Debian, :RedHat]
 
   def install
   end
@@ -13,11 +14,11 @@ Puppet::Type.type(:cpan).provide( :default ) do
   def create
     Puppet.info("Installing cpan module #{resource[:name]}. This can take awhile.")
 
-    system("/usr/bin/cpan #{resource[:name]} > /dev/null 2>&1")
+    system("cpan #{resource[:name]} > /dev/null 2>&1")
     estatus = $?.exitstatus
 
     if estatus != 0
-      raise Puppet::Error, "/usr/bin/cpan #{resource[:name]} failed with error code #{estatus}"
+      raise Puppet::Error, "cpan #{resource[:name]} failed with error code #{estatus}"
     end
   end
 
@@ -26,7 +27,7 @@ Puppet::Type.type(:cpan).provide( :default ) do
 
   def exists?
     Puppet.debug("perl -M#{resource[:name]} -e1 > /dev/null 2>&1")
-    output = system("/usr/bin/perl -M#{resource[:name]} -e1 > /dev/null 2>&1")
+    output = system("perl -M#{resource[:name]} -e1 > /dev/null 2>&1")
     estatus = $?.exitstatus
 
     case estatus
@@ -36,7 +37,7 @@ Puppet::Type.type(:cpan).provide( :default ) do
       Puppet.debug("#{resource[:name]} not installed. Installing..")
       false
     else
-      raise Puppet::Error, "/usr/bin/perl -M#{resource[:name]} -e1 failed with error code #{estatus}: #{output}"
+      raise Puppet::Error, "perl -M#{resource[:name]} -e1 failed with error code #{estatus}: #{output}"
     end
   end
 


### PR DESCRIPTION
Removed '/usr/bin' portions of commands and sets because different systems may have these binaries in different places of PATH. Relying on ENV['PATH'].

Also added a confine since the osfamily supported set is restricted to Debian and RedHat types. The original module isn't making use of :osfamily which a pending pull request will change the case statement to use this fact in init.pp.
