### PR TITLE
On Debian systems don't require 'perl-modules'.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,7 +26,7 @@ class cpan::params {
   }
   case $::osfamily {
     'Debian': {
-      $common_os_package = ['perl-modules']
+      $common_os_package = ['perl']
       if $local_lib {
         $local_lib_package  = ['liblocal-lib-perl']
       } else {

--- a/spec/classes/cpan_spec.rb
+++ b/spec/classes/cpan_spec.rb
@@ -34,7 +34,7 @@ describe 'cpan', :type => 'class' do
         it { should contain_package('make').with(:ensure => 'present') }
 
         if system == 'Debian'
-          it { should contain_package('perl-modules').with(:ensure => 'present') }
+          it { should contain_package('perl').with(:ensure => 'present') }
         end
 
         if system == 'RedHat'
@@ -46,7 +46,7 @@ describe 'cpan', :type => 'class' do
           it { should contain_package('gcc').with_ensure('latest') }
           it { should contain_package('make').with_ensure('latest') }
           if system == 'Debian'
-            it { should contain_package('perl-modules').with(:ensure => 'latest') }
+            it { should contain_package('perl').with(:ensure => 'latest') }
           end
           if system == 'RedHat'
             it { should contain_package('perl-CPAN').with(:ensure => 'latest') }


### PR DESCRIPTION
Instead simply require 'perl', which will pull in 'perl-modules' as a
dependency. Since Debian Stretch perl-modules is a virtual package which
ATM can't be managed with puppet.