### PR TITLE
support environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ class {'::cpan':
   config_hash    => { 'build_requires_install_policy' => 'no' },
   ftp_proxy      => 'http://your_ftp_proxy.com',
   http_proxy     => 'http://your_http_proxy.com',
+  environment    => {
+  	'OPTIONAL_ENVIRONMENT_VAR_1' => '1',
+  	'OPTIONAL_ENVIRONMENT_VAR_2' => '/foo/bar',
+  },
 }
 ```
 
@@ -111,6 +115,18 @@ class {'::cpan':
 }
 ```
 
+### Add additional environment variables
+
+Some modules may require additional environment variables to be set *e.g.* during install, like `DBD::Oracle` or `DBD::DB2`.
+
+```puppet
+cpan {'DBD::DB2':
+  ensure      => 'latest',
+  environment => {
+   'DB2_HOME' => '/path/to/DB2,
+  }
+}
+```
 
 ## Reference
 
@@ -140,6 +156,8 @@ class {'::cpan':
 #### `ftp_proxy`
 
 #### `http_proxy`
+
+#### `environment`
 
 ## Limitations
 

--- a/lib/puppet/provider/cpan/default.rb
+++ b/lib/puppet/provider/cpan/default.rb
@@ -32,6 +32,11 @@ Puppet::Type.type(:cpan).provide( :default ) do
     end
 
     umask = "umask #{resource[:umask]};" if resource[:umask]
+    if resource[:environment]
+      resource[:environment].each do |var, val|
+        ENV[var] = val
+      end
+    end
 
     Puppet.debug("cpan #{resource[:name]}")
     if resource.force?
@@ -60,6 +65,11 @@ Puppet::Type.type(:cpan).provide( :default ) do
       ll = "-Mlocal::lib=#{resource[:local_lib]}"
     end
     umask = "umask #{resource[:umask]};" if resource[:umask]
+    if resource[:environment]
+      resource[:environment].each do |var, val|
+        ENV[var] = val
+      end
+    end
 
     if resource.force?
       Puppet.info("Forcing upgrade for #{resource[:name]}")

--- a/lib/puppet/type/cpan.rb
+++ b/lib/puppet/type/cpan.rb
@@ -31,6 +31,13 @@ Puppet::Type.newtype(:cpan) do
     desc 'Destination directory or `false`'
   end
 
+  newparam(:environment) do
+    desc 'List of environment variables in the form of a Hash'
+    validate do |value|
+      raise ArgumentError, 'Hash expected for environment' unless value.is_a?(Hash)
+    end
+  end
+
   newparam(:force, :boolean => true, :parent => Puppet::Parameter::Boolean) do
     desc 'Enable/Disable to force the installation of the module. Disabled by default.'
     defaultto :false

--- a/test/environment.pp
+++ b/test/environment.pp
@@ -1,0 +1,16 @@
+#
+class { '::cpan':
+  manage_package => false,
+  manage_config  => false,
+}
+
+Cpan {
+  local_lib => '/tmp/CPAN'
+}
+
+cpan { 'DBD::DB2':
+  ensure      => present,
+  environment => {
+    'DB2_HOME' => '/tmp/db2'
+  }
+}


### PR DESCRIPTION
```puppet
cpan {'DBD::DB2':
  ensure      => 'latest',
  environment => {
    'DB2_HOME' => '/path/to/DB2,
  }
}
```
Fixes #47