### PR TITLE
Removed perl-CPAN

### DIFF
--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -7,6 +7,5 @@ cpan::config_file:
 cpan::manage_package: true
 cpan::package_name:
   - perl
-  - perl-CPAN
 cpan::local_lib_package_name:
   - liblocal-lib-perl


### PR DESCRIPTION
Good day

I removed perl-CPAN, for it is not available in the the Debian repository.

Please consider my PR

Many thanks
Regards
Brent Clark