### PR TITLE
params.pp uses concat with 3 arrays, it needs stdlib 4.6.0 [ccin2p3/p…

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 2.2.0 < 6.0.0"
+      "version_requirement": ">= 4.6.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
…uppet-cpan#57]

https://github.com/puppetlabs/puppetlabs-stdlib/blob/4.6.x/CHANGELOG.md
updated concat to support multiple arrays.

If we use less then that, we get
`Error 400 on SERVER: concat(): Wrong number of arguments given (3 for 2) at`
for `cpan/manifests/params.pp:50`