### PR TITLE
Update to remove ensure notices on latest ensure along with altered

### DIFF
--- a/lib/puppet/provider/cpan/default.rb
+++ b/lib/puppet/provider/cpan/default.rb
@@ -10,16 +10,29 @@ Puppet::Type.type(:cpan).provide(:default) do
 
   def force; end
 
-  def latest?
+  def version
     if resource[:local_lib]
       ll = "-Mlocal::lib=#{resource[:local_lib]}"
     end
     current_version = `perl #{ll} -M#{resource[:name]} -e 'print $#{resource[:name]}::VERSION'`
+    current_version.chomp
+    return current_version
+  end
+
+  def latest
+    if resource[:local_lib]
+      ll = "-Mlocal::lib=#{resource[:local_lib]}"
+    end
     cpan_str = `perl #{ll} -e 'use CPAN; my $mod=CPAN::Shell->expand("Module","#{resource[:name]}"); \
                 printf("%s", $mod->cpan_version eq "undef" || !defined($mod->cpan_version) ? "-" : $mod->cpan_version);'`
     latest_version = cpan_str.match(%r{^[0-9]+.?[0-9]*$})[0]
-    current_version.chomp
     latest_version.chomp
+    return latest_version
+  end
+
+  def latest?
+    current_version = self.version
+    latest_version = self.latest
     if current_version < latest_version
       return false
     end

--- a/lib/puppet/type/cpan.rb
+++ b/lib/puppet/type/cpan.rb
@@ -21,6 +21,24 @@ Puppet::Type.newtype(:cpan) do
         provider.update
       end
     end
+
+    def insync?(is)
+      @should ||= []
+      if is == :absent
+        provider.create
+      end
+      if should == :present
+        return true unless [:absent, :purged, :held].include?(is)
+      end
+      if should == :latest
+        if provider.latest?
+          return true
+        end
+        self.debug "CPAN Module %s version is out of date, installed version: %s, latest version: %s" %
+                [@resource.name, provider.version, provider.latest]
+       return false
+      end
+    end
   end
 
   newparam(:name) do


### PR DESCRIPTION
Update to remove ensure notices on latest ensure along with altered exit code from puppet run.

2021-04-20 08:06:00 -0600 /Stage[main]/<module>/Cpan[Date::Parse]/ensure
(notice): ensure changed 'present' to 'latest' (corrective)