### PR TITLE
replace deprecated validate_* with datatypes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,8 @@
 #
 # [*manage_package*]
 #
+# [*package_name*]
+#
 # [*installdirs*]
 #
 # [*local_lib*]
@@ -21,6 +23,8 @@
 # [*ftp_proxy*]
 #
 # [*http_proxy*]
+#
+# [*urllist*]
 #
 # === Examples
 #
@@ -36,35 +40,20 @@
 # }
 #
 class cpan (
-  $manage_package,
-  $config_hash,
-  $package_name,
+  Boolean $manage_package,
+  Hash $config_hash,
+  String $package_name,
   Optional[Array[String[1]]] $config_file = undef,
   Optional[Array[String[1]]] $config_dir = undef,
-  $package_ensure    = 'present',
-  $manage_config     = true,
-  $installdirs       = 'site',
-  $local_lib         = false,
-  $config_template   = 'cpan/cpan.conf.erb',
-  $ftp_proxy         = undef,
-  $http_proxy        = undef,
-  $urllist           = [],
+  String $package_ensure        = 'present',
+  Boolean $manage_config        = true,
+  String $installdirs           = 'site',
+  Boolean $local_lib            = false,
+  String $config_template       = 'cpan/cpan.conf.erb',
+  Optional[String] $ftp_proxy   = undef,
+  Optional[String] $http_proxy  = undef,
+  Array $urllist                = [],
 ) {
-
-  validate_bool($manage_config)
-  validate_bool($manage_package)
-  validate_string($installdirs)
-  validate_bool($local_lib)
-  validate_string($config_template)
-  validate_string($package_ensure)
-  if $ftp_proxy {
-    validate_string($ftp_proxy)
-  }
-  if $http_proxy {
-    validate_string($http_proxy)
-  }
-  validate_array($urllist)
-
   anchor { 'cpan::begin': }
   -> class { '::cpan::install': }
   -> class { '::cpan::config': }


### PR DESCRIPTION
stdlib 9.0 removed the deprecated _validate__ functions (https://github.com/puppetlabs/puppetlabs-stdlib/pull/1352)

This PR removes them and sets datatypes for the parameters instead.

I also added some params to the documentation comment block which were missing.